### PR TITLE
Per resource namespaces on genesis and account generation

### DIFF
--- a/docs/creating-a-new-cluster.md
+++ b/docs/creating-a-new-cluster.md
@@ -151,15 +151,28 @@ rm -rf .dscp-cluster-gpg
 
 #### Creating the genesis
 
-To bootstrap the cluster we need to create a chain genesis file along with the associated node key secrets. This can be done using the [`make-new-cluster-genesis.sh`](../scripts/make-new-cluster-genesis.sh) script. Note this script will not overwrite pre-existing node keys so before running ensure that no node keys already exist (encrypted on otherwise) in the `/clusters/<cluster_name>/secrets` folder. This folder must exist.
+To bootstrap the cluster we need to create a chain genesis file along with the associated node key secrets and account secrets. This can be done using the [`make-new-cluster-genesis.sh`](../scripts/make-new-cluster-genesis.sh) script. Note this script will not overwrite pre-existing node keys or account keys so before running ensure that none already exist (encrypted on otherwise) in the `/clusters/<cluster_name>/secrets` folder. This folder must exist.
 
 The described script allows for generating a new cluster with any number of desired validator nodes and additional nodes for instantiation as required. For example:
 
 ```
-./scripts/make-new-cluster-genesis.sh -v red -v green -v blue -a bootnode -a api-light new-cluster > new-cluster.json
+./scripts/make-new-cluster-genesis.sh \
+    -o alice:ns1
+    -o bob:ns2
+    -o charlie:ns3
+    -v red:ns1:alice \
+    -v green:ns2:bob \
+    -v blue:ns3:charlie \
+    -a bootnode:ns1:alice \
+    -a api-light:ns1:alice \
+    -a api-light:ns2:bob \
+    -a api-light:ns3:charlie \
+    new-cluster > new-cluster.json
 ```
 
-would create a genesis for a new cluster called `new-cluster` with three validator nodes (called `red`, `green` and `blue`) along with two additional nodes (`bootnode` and `api-light`). Additional options may be specified to configure the docker image used to generate the genesis (defaults to `ghcr.io/digicatapult/vitalam-node:latest`) and the kubernetes namespace secrets should be created in (defaults to `dscp`). The script writes the final raw genesis file to stdout so can be safely redirected. This should then either be hosted publicly or built into the node to be deployed so that the chain can be referenced.
+would create a genesis for a new cluster called `new-cluster`. Three accounts `alice`, `bob` and `charlie` would be created in the namespaces `ns1`, `ns2` and `ns3` respectively. Three validator nodes called `red`, `green` and `blue` would be created in namespaces `ns1`, `ns2` and `ns3` and with owners `alice`, `bob` and `charlie` respectively. Two additional nodes (`bootnode` and `api-light`) would be created in `ns1` and owned by `alice`. Finally namespaces `ns2` and `ns3` would both contain an additional node called `api-light` owned by `bob` and `charlie` respectively.
+
+Additional options may be specified to configure the docker image used to generate the genesis (defaults to `ghcr.io/digicatapult/vitalam-node:latest`) and the kubernetes namespace secrets should be created in (defaults to `dscp`). The script writes the final raw genesis file to stdout so can be safely redirected. This should then either be hosted publicly or built into the node to be deployed so that the chain can be referenced.
 
 #### Creating additional secrets
 

--- a/scripts/make-cluster-account-secret.sh
+++ b/scripts/make-cluster-account-secret.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 
 print_usage() {
-  echo "Makes a kubernetes secret containing keys for a dscp-node. The final line of this script will output a JSON object containing the new node's PeerId, AuraId and GrandpaId."
+  echo "Makes a kubernetes secret containing keys for a dscp account. The final line of this script will output a JSON object containing the new account's accountId."
   echo ""
   echo "Usage:"
-  echo "  ./scripts/make-cluster-node-secret.sh [ -h ] [ -f ] [ -n <namespace> ] [ -c <container> ] <cluster_name> <node_name>"
+  echo "  ./scripts/make-cluster-account-secret.sh [ -h ] [ -f ] [ -n <namespace> ] [ -c <container> ] <cluster_name> <account_name>"
   echo ""
   echo "Example Usage:"
-  echo "  ./scripts/make-cluster-node-secret.sh inteli-stage red"
+  echo "  ./scripts/make-cluster-account-secret.sh inteli-stage api"
   echo ""
   echo "Flags: "
   echo "  -h              Print this message"
-  echo "  -f              Force re-creation of new secret for an existing node. Note this is destructive"
+  echo "  -f              Force re-creation of new secret for an existing account. Note this is destructive"
   echo "  -c <container>  Container image to use for key generation"
   echo "  -n <namespace>  Namespace in which to create the secret. Defaults to dscp"
 }
@@ -48,7 +48,7 @@ while getopts ":n:c:fh" opt; do
 done
 shift $((OPTIND -1))
 CLUSTER=$1
-NODE_NAME=$2
+ACCOUNT_NAME=$2
 
 assert_cluster() {
   local cluster=$1
@@ -61,18 +61,18 @@ assert_cluster() {
   printf "OK\n" >&2
 }
 
-assert_not_node() {
+assert_not_account() {
   local cluster=$1
   local namespace=$2
-  local node_name=$3
+  local account_name=$3
 
-  printf "Checking node $node_name:$namespace does not already exist in cluster $cluster..." >&2
+  printf "Checking account $account_name:$namespace does not already exist in cluster $cluster..." >&2
   if [ ! -z "$FORCE_RECREATE" ]; then
     printf "SKIP\n" >&2
   else
-    if [ -f "./clusters/$cluster/secrets/${node_name}_${namespace}_node-keys.yaml" ] ||
-       [ -f "./clusters/$cluster/secrets/${node_name}_${namespace}_node-keys.unc.yaml" ]; then
-      echo -e "Node $node_name:${namespace} already exists in cluster $cluster. Use -f to overrite anyway." >&2
+    if [ -f "./clusters/$cluster/secrets/${account_name}_${namespace}_account-keys.yaml" ] ||
+       [ -f "./clusters/$cluster/secrets/${account_name}_${namespace}_account-keys.unc.yaml" ]; then
+      echo -e "Account $account_name:${namespace} already exists in cluster $cluster. Use -f to overrite anyway." >&2
       exit 1
     fi
     printf "OK\n" >&2
@@ -116,36 +116,16 @@ pull_container() {
   fi
 }
 
-NODE_KEY=
-NODE_ID=
-generate_node_key() {
+ACCOUNT_SEED=
+ACCOUNT_ADDR=
+generate_account_key() {
   local container=$1
 
-  printf "Generating node-key..." >&2
-  if output=$(docker run --rm -t $container key generate-node-key 2>&1); then
+  printf "Generating account-key..." >&2
+  if output=$(docker run --rm -t $container key generate --scheme Sr25519 --output-type Json 2>&1); then
     printf "OK\n" >&2
-    output=(${output[@]})
-    NODE_ID=(${output[0]})
-    NODE_KEY=(${output[1]})
-  else
-    printf "FAIL\n" >&2
-    echo "$output" >&2
-    exit 1
-  fi
-}
-
-AUTH_KEY=
-AUTH_ADDR=
-generate_authority_key() {
-  local container=$1
-  local scheme=$2
-  local output=
-
-  printf "Generating authority key with scheme $scheme..." >&2
-  if output=$(docker run --rm -t $container key generate --scheme $scheme --output-type Json 2>&1); then
-    printf "OK\n" >&2
-    AUTH_KEY=$(echo $output | jq -r .secretPhrase)
-    AUTH_ADDR=$(echo $output | jq -r .ss58Address)
+    ACCOUNT_SEED=$(echo $output | jq -r .secretPhrase)
+    ACCOUNT_ADDR=$(echo $output | jq -r .ss58Address)
   else
     printf "FAIL\n" >&2
     echo "$output" >&2
@@ -156,20 +136,16 @@ generate_authority_key() {
 create_k8s_secret() {
   local cluster=$1
   local namespace=$2
-  local node_name=$3
-  local node_key=$4
-  local aura_seed=$5
-  local grandpa_seed=$6
+  local account_name=$3
+  local account_seed=$4
 
-  printf "Generating k8s secret for $node_name..." >&2
-  kubectl create secret generic ${node_name}-keys \
+  printf "Generating k8s secret for $account_name..." >&2
+  kubectl create secret generic ${account_name}-keys \
     --type=Opaque \
     --namespace=$namespace \
-    --from-literal=node_id=$node_key \
-    --from-literal=aura_seed="$aura_seed" \
-    --from-literal=grandpa_seed="$grandpa_seed" \
+    --from-literal=acount_seed="$account_seed" \
     --dry-run=client \
-    --output=yaml > ./clusters/${cluster}/secrets/${node_name}_${namespace}_node-keys.unc.yaml
+    --output=yaml > ./clusters/${cluster}/secrets/${account_name}_${namespace}_account-keys.unc.yaml
 
   if [ "$?" -ne "0" ]; then
     printf "FAIL\n" >&2
@@ -184,25 +160,15 @@ assert_command docker
 assert_command jq
 assert_cluster $CLUSTER
 assert_namespace $NAMESPACE
-assert_not_node $CLUSTER $NAMESPACE $NODE_NAME
+assert_not_account $CLUSTER $NAMESPACE $ACCOUNT_NAME
 # make sure we can pull the container
 pull_container $CONTAINER
 
 # Generate keys
-generate_node_key $CONTAINER
-generate_authority_key $CONTAINER Sr25519
-AURA_ADDR=$AUTH_ADDR
-AURA_SEED=$AUTH_KEY
-generate_authority_key $CONTAINER Ed25519
-GRANDPA_ADDR=$AUTH_ADDR
-GRANDPA_SEED=$AUTH_KEY
+generate_account_key $CONTAINER
 
 # generate kubernetes secret
-create_k8s_secret "$CLUSTER" "$NAMESPACE" "$NODE_NAME" "$NODE_KEY" "$AURA_SEED" "$GRANDPA_SEED"
+create_k8s_secret "$CLUSTER" "$NAMESPACE" "$ACCOUNT_NAME" "$ACCOUNT_SEED"
 
 # Generate output as JSON
-echo $(jq --null-input \
-  --arg node_id $NODE_ID \
-  --arg aura_id $AURA_ADDR \
-  --arg grandpa_id $GRANDPA_ADDR \
-  '{ "nodeId": $node_id, "auraId": $aura_id, "grandpaId": $grandpa_id }')
+echo $(jq --null-input --arg account_addr $ACCOUNT_ADDR '{ "accountId": $account_addr }')

--- a/scripts/make-new-cluster-genesis.sh
+++ b/scripts/make-new-cluster-genesis.sh
@@ -4,41 +4,50 @@ print_usage() {
   echo "TODO"
   echo ""
   echo "Usage:"
-  echo "  ./scripts/make-new-cluster-genesis.sh [ -h ] [ -n <namespace> ] [ -b <base_chain> ] [ -c <container> ] [ -v <validator_node_name> ] [ -a <additional_node_name> ] <cluster_name>"
+  echo "  ./scripts/make-new-cluster-genesis.sh [ -h ] [ -b <base_chain> ] [ -c <container> ] [ -v <validator_node_name> ] [ -a <additional_node_name> ] <cluster_name>"
   echo ""
   echo "Example Usage:"
   echo "  # Create keys and a genesis for cluster inteli-stage with three validator nodes (red, green, blue) and two additional nodes (bootnode, api-light)"
   echo "  ./scripts/make-new-cluster-genesis.sh -v red -v green -v blue -a bootnode -a api-light inteli-stage"
   echo ""
   echo "Flags: "
-  echo "  -h                         Print this message"
-  echo "  -n <namespace>             Namespace in which to create the secret. Defaults to `dscp`"
-  echo "  -b <base_chain>            Base chain-spec to generate spec from. Defaults to `local`."
-  echo "  -c <container>             Container image to use for key generation. Defaults to ghcr.io/digicatapult/vitalam-node:latest"
-  echo "  -v <validator_node_name>   Adds a validator node with name <validator_node_name>. To add multiple validators add multiple -v flags"
-  echo "  -a <additional_node_name>  Adds an additional (non-validator) node with name <additional_node_name>. To add multiple additional nodes add multiple -a flags"
+  echo "  -h                                            Print this message"
+  echo "  -n <namespace>                                Namespace in which to create the secret. Defaults to dscp"
+  echo "  -b <base_chain>                               Base chain-spec to generate spec from. Defaults to local"
+  echo "  -c <container>                                Container image to use for key generation."
+  echo "                                                Defaults to ghcr.io/digicatapult/vitalam-node:latest"
+  echo "  -o <owner>:<namespace>:<balance>              Adds a node owner account giving the specified balance."
+  echo "                                                The secret for the owner will be placed in the Kubernetes <namespace>"
+  echo "  -v <validator_node_name>:<namespace>:<owner>  Adds a validator node with name <validator_node_name> which will be owned by <owner>."
+  echo "                                                The secrets will be added to the specified Kubernetes <namespace>."
+  echo "                                                The <owner> must be in the same namesapce as the node."
+  echo "                                                To add multiple validators add multiple -v flags"
+  echo "  -a <additional_node_name:<namespace>:<owner>  Adds an additional (non-validator) node with name <additional_node_name>"
+  echo "                                                which will be owned by <owner>. The secrets will be added to the specified"
+  echo "                                                Kubernetes <namespace>. The <owner> must be in the same namesapce as the node."
+  echo "                                                To add multiple additional nodes add multiple -a flags"
 }
 
-NAMESPACE="dscp"
 BASE_CHAIN="local"
 CONTAINER="ghcr.io/digicatapult/vitalam-node:latest"
+OWNER_NAMES=()
 VALIDATOR_NAMES=()
 ADDITIONAL_NAMES=()
 GENESIS=
-while getopts ":n:b:c:v:a:h" opt; do
+while getopts ":b:c:o:v:a:h" opt; do
   case ${opt} in
     h )
       print_usage
       exit 0
-      ;;
-    n )
-      NAMESPACE=${OPTARG}
       ;;
     b )
       BASE_CHAIN=${OPTARG}
       ;;
     c )
       CONTAINER=${OPTARG}
+      ;;
+    o )
+      OWNER_NAMES+=("${OPTARG}")
       ;;
     v )
       VALIDATOR_NAMES+=("${OPTARG}")
@@ -74,15 +83,34 @@ assert_cluster() {
 
 assert_not_node() {
   local cluster=$1
-  local node_name=$2
+  local namespace=$2
+  local node_name=$3
 
-  printf "Checking node $node_name does not already exist in cluster $cluster..." >&2
+  printf "Checking node $node_name:$namespace does not already exist in cluster $cluster..." >&2
   if [ ! -z "$FORCE_RECREATE" ]; then
     printf "SKIP\n" >&2
   else
-    if [ -f "./clusters/$cluster/secrets/${node_name}_keys.yaml" ] ||
-       [ -f "./clusters/$cluster/secrets/${node_name}_keys.unc.yaml" ]; then
-      echo -e "Node $node_name already exists in cluster $cluster. Use -f to overrite anyway." >&2
+    if [ -f "./clusters/$cluster/secrets/${node_name}_${namespace}_node-keys.yaml" ] ||
+       [ -f "./clusters/$cluster/secrets/${node_name}_${namespace}_node-keys.unc.yaml" ]; then
+      echo -e "Node $node_name already exists in cluster $cluster" >&2
+      exit 1
+    fi
+    printf "OK\n" >&2
+  fi
+}
+
+assert_not_account() {
+  local cluster=$1
+  local namespace=$2
+  local account_name=$3
+
+  printf "Checking account $account_name:$namespace does not already exist in cluster $cluster..." >&2
+  if [ ! -z "$FORCE_RECREATE" ]; then
+    printf "SKIP\n" >&2
+  else
+    if [ -f "./clusters/$cluster/secrets/${account_name}_${namespace}_account-keys.yaml" ] ||
+       [ -f "./clusters/$cluster/secrets/${account_name}_${namespace}_account-keys.unc.yaml" ]; then
+      echo -e "Account $account_name:$namespace already exists in cluster $cluster" >&2
       exit 1
     fi
     printf "OK\n" >&2
@@ -98,7 +126,57 @@ assert_label() {
     echo -e "$name is not a valid Kubernetes name" >&2
     exit 1
   fi
-  printf "OK'\n" >&2
+  printf "OK\n" >&2
+}
+
+assert_balance() {
+  local balance=$1
+  printf "Checking that balance $balance is valid..." >&2
+  if [[ ! $balance =~ ^[1-9][0-9]*$ ]]; then
+    echo -e "$balance is not a valid integer" >&2
+    exit 1
+  fi
+  printf "OK\n" >&2
+}
+
+assert_node_valid() {
+  local node_input=$1
+  local node=$(echo $node_input | cut -f1 -d:)
+  local namespace=$(echo $node_input | cut -f2 -d:)
+  local node_owner=$(echo $node_input | cut -f3 -d:)
+  local owner_name=
+  local owner_namespace=
+
+  assert_label "namespace" $namespace
+  assert_label "name" $node
+  assert_not_node "$CLUSTER" "$namespace" "$node"
+
+  assert_label "owner" $node_owner
+  printf "Checking that owner for node $node is valid..." >&2
+  for owner in "${OWNER_NAMES[@]}"
+  do
+    owner_name=$(echo $owner | cut -f1 -d:)
+    owner_namespace=$(echo $owner | cut -f2 -d:)
+    if [[ "$namespace" == "$owner_namespace" ]] && [[ "$node_owner" == "$owner_name" ]]; then
+      printf "OK\n" >&2
+      return 0
+    fi
+  done
+
+  printf "Owner is not [resent in account list\n" >&2
+  exit 1
+}
+
+assert_owner_valid() {
+  local owner_input=$1
+  local owner=$(echo $owner_input | cut -f1 -d:)
+  local namespace=$(echo $owner_input | cut -f2 -d:)
+  local balance=$(echo $owner_input | cut -f3 -d:)
+
+  assert_label "namespace" $namespace
+  assert_label "owner" $owner
+  assert_balance $balance
+  assert_not_account "$CLUSTER" "$namespace" "$owner"
 }
 
 assert_command() {
@@ -162,18 +240,60 @@ generate_sudo() {
   fi
 }
 
-generate_validator() {
+OWNER_ACCOUNTS=()
+generate_owner() {
   local cluster=$1
-  local namespace=$2
+  local container=$2
+  local owner_name_namespace_balance=$3
+
+  local owner_name=$(echo "$owner_name_namespace_balance" | cut -f1 -d:)
+  local owner_namespace=$(echo "$owner_name_namespace_balance" | cut -f2 -d:)
+  local owner_balance=$(echo "$owner_name_namespace_balance" | cut -f3 -d:)
+
+  printf "Generating owner account ${owner_name}:${owner_namespace}..." >&2
+  if output=$(./scripts/make-cluster-account-secret.sh -n $owner_namespace -c $container $cluster $owner_name 2>/dev/null); then
+    printf "OK\n" >&2
+    account_id=$(echo $output | jq -r '.accountId')
+    OWNER_ACCOUNTS+=("${owner_name}:${owner_namespace}:${account_id}")
+    GENESIS=$(echo $GENESIS | jq --arg account_id $account_id --arg balance $owner_balance '.genesis.runtime.palletBalances.balances += [[$account_id, ($balance | tonumber)]]')
+    GENESIS=$(echo $GENESIS | jq --arg account_id $account_id '.genesis.runtime.palletMembership.members += [$account_id]')
+  else
+    printf "FAIL\n" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+}
+
+generate_node() {
+  local type=$1
+  local cluster=$2
   local container=$3
-  local node_name=$4
-  local owner=$5
+  local node_name_namespace_owner=$4
+
+  local node_name=$(echo "$node_name_namespace_owner" | cut -f1 -d:)
+  local namespace=$(echo "$node_name_namespace_owner" | cut -f2 -d:)
+  local node_owner=$(echo "$node_name_namespace_owner" | cut -f3 -d:)
+  local node_owner_account=
+
   local output=
   local node_id=
   local aura_id=
   local grandpa_id=
+  local owner_name=
+  local owner_namespace=
+  local owner_account=
 
-  printf "Generating keys for validator $node_name..." >&2
+  for owner in "${OWNER_ACCOUNTS[@]}"
+  do
+    owner_name=$(echo $owner | cut -f1 -d:)
+    owner_namespace=$(echo $owner | cut -f2 -d:)
+    owner_account=$(echo $owner | cut -f3 -d:)
+    if [[ "$namespace" == "$owner_namespace" ]] && [[ "$node_owner" == "$owner_name" ]]; then
+      node_owner_account=$owner_account
+    fi
+  done
+
+  printf "Generating keys for $type node $node_name..." >&2
   if output=$(./scripts/make-cluster-node-secret.sh -n $namespace -c $container $cluster $node_name 2>/dev/null); then
     printf "OK\n" >&2
     # extract ids
@@ -181,18 +301,20 @@ generate_validator() {
     aura_id=$(echo $output | jq -r '.auraId')
     grandpa_id=$(echo $output | jq -r '.grandpaId')
     # update genesis
-    GENESIS=$(echo $GENESIS | jq --arg aura_id $aura_id '.genesis.runtime.palletAura.authorities += [$aura_id]')
-    GENESIS=$(echo $GENESIS | jq --arg grandpa_id $grandpa_id '.genesis.runtime.palletGrandpa.authorities += [[$grandpa_id, 1]]')
+    if [ "$type" == "validator" ]; then
+      GENESIS=$(echo $GENESIS | jq --arg aura_id $aura_id '.genesis.runtime.palletAura.authorities += [$aura_id]')
+      GENESIS=$(echo $GENESIS | jq --arg grandpa_id $grandpa_id '.genesis.runtime.palletGrandpa.authorities += [[$grandpa_id, 1]]')
+    fi
     # convert node_id to hex
     node_id=$(docker run --rm -a stdout python:alpine /bin/sh -c "\
       pip install base58 1>/dev/null; \
       printf \"$node_id\" | base58 -d | xxd -p | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]'")
     node_id=($(echo $node_id | fold -w2))
 
-    GENESIS=$(echo $GENESIS | jq --arg sudo_id $owner '.genesis.runtime.palletNodeAuthorization.nodes += [[[], $sudo_id]]')
+    GENESIS=$(echo $GENESIS | jq --arg owner $node_owner_account '.genesis.runtime.palletNodeAuthorization.nodes += [[[], $owner]]')
     for byte in "${node_id[@]}"
     do
-      GENESIS=$(echo $GENESIS | jq --arg sudo_id $owner --arg byte $(echo "obase=10; ibase=16; $byte" | bc) '.genesis.runtime.palletNodeAuthorization.nodes[-1][0] += [($byte | tonumber)]')
+      GENESIS=$(echo $GENESIS | jq --arg byte $(echo "obase=10; ibase=16; $byte" | bc) '.genesis.runtime.palletNodeAuthorization.nodes[-1][0] += [($byte | tonumber)]')
     done
   else
     printf "FAIL\n" >&2
@@ -205,18 +327,20 @@ assert_command kubectl
 assert_command docker
 assert_command jq
 assert_cluster $CLUSTER
-assert_label "namespace" $NAMESPACE
+
+for owner in "${OWNER_NAMES[@]}"
+do
+  assert_owner_valid $owner
+done
 
 for validator_name in "${VALIDATOR_NAMES[@]}"
 do
-  assert_label "name" "$validator_name"
-  assert_not_node "$CLUSTER" "$validator_name"
+  assert_node_valid $validator_name
 done
 
 for additional_name in "${ADDITIONAL_NAMES[@]}"
 do
-  assert_label "name" "$additional_name"
-  assert_not_node "$CLUSTER" "$additional_name"
+  assert_node_valid $additional_name
 done
 
 # make sure we can pull the container
@@ -238,11 +362,22 @@ GENESIS=$(echo $GENESIS | jq '.genesis.runtime.palletMembership.members |= []')
 # Generate sudo
 generate_sudo $CONTAINER
 
+# loop through nodes and add them in
+for owner in "${OWNER_NAMES[@]}"
+do
+  generate_owner $CLUSTER $CONTAINER $owner
+done
+
 # loop through validators and add them in
-NODE_CREATE_OUTPUT=
 for validator_name in "${VALIDATOR_NAMES[@]}"
 do
-  generate_validator $CLUSTER $NAMESPACE $CONTAINER $validator_name $SUDO_ADDR
+  generate_node "validator" $CLUSTER $CONTAINER $validator_name
+done
+
+# loop through additional nodes and add them in
+for additional_name in "${ADDITIONAL_NAMES[@]}"
+do
+  generate_node "additional" $CLUSTER $CONTAINER $additional_name
 done
 
 GENESIS_DIR=$(mktemp -d -t inteli-genesis.XXXXXX)

--- a/scripts/make-new-cluster-genesis.sh
+++ b/scripts/make-new-cluster-genesis.sh
@@ -152,7 +152,7 @@ assert_node_valid() {
   assert_not_node "$CLUSTER" "$namespace" "$node"
 
   assert_label "owner" $node_owner
-  printf "Checking that owner for node $node is valid..." >&2
+  printf "Checking that owner for node $node:$namespace is valid..." >&2
   for owner in "${OWNER_NAMES[@]}"
   do
     owner_name=$(echo $owner | cut -f1 -d:)
@@ -163,7 +163,7 @@ assert_node_valid() {
     fi
   done
 
-  printf "Owner is not [resent in account list\n" >&2
+  printf "Owner is not present in account list\n" >&2
   exit 1
 }
 


### PR DESCRIPTION
This PR updates our scripts to allow:

* Nodes generated by the genesis script can now be placed in separate namespaces
* Accounts can now be generated, with balances and as chain members
* Node owners are now assigned to accounts generated not sudo