### PR TITLE
genesis secrets for inteli-stage

### DIFF
--- a/clusters/inteli-stage/secrets/api-ipfs-light_oem_node-keys.yaml
+++ b/clusters/inteli-stage/secrets/api-ipfs-light_oem_node-keys.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+data:
+    aura_seed: ENC[AES256_GCM,data:F/pFaVUMsangirFlCDXWMHWui+OZkSa6xme3uyJZVQGigB8/DDZfX4H1CfKo1pRmjypBufvUAEzJhsT/vg5SKf352YDA5oFsNwWz+EpfZ1jlJmsOioO/2Yl280cmzoj0MaRAE8hgpkXw+H9fX1qX2A==,iv:xh/B2v70nx8QXLh9F3GctENHaSaCUP5ueO4QfLeetCQ=,tag:OHpTf/M8zsWeVAYDzQag2w==,type:str]
+    grandpa_seed: ENC[AES256_GCM,data:GsgxBOCzYmv9XJ2/e3iwmLLEUMwp3fzweHdRwxeFSpBzyZim5YeJ0J3OiUtfba9qBOPJtbAsqaTtIj0r5UhW2busMCjN130D2xYbum4PmzU4FPYgDVZYPmHqpzsvLim68dtM8TFllUbifzc0,iv:QonkTqh5ikCGdEQQEcaxOXD9OPlR+17oFN/rSd6pLSs=,tag:8qDSSL93nmA48O3vV1Z1tg==,type:str]
+    node_id: ENC[AES256_GCM,data:snOaxsd3vQFHnRj+mP4WBBIA5fRu2jvweo9k7toy6uaL/WXbZZZ4d7/jxNCVFkNNPdG6sXnx1GxSD8wmCDr4e+2fdo9b6BBgNUrD3wSbwKiG01gDky1pFw==,iv:IT/eq5W1etgb7xFcb4SWsoACruVntCZCu9pJIhCPjoU=,tag:ITHXdfl8X9NTrt7I6H0+aQ==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: api-ipfs-light-keys
+    namespace: oem
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-02-10T10:55:44Z"
+    mac: ENC[AES256_GCM,data:0fcqEPDvL22JcwYm/tzlvaKFcmm4/iX3KQZPpicv8P9ahT31UN1FpB7sGu4xh/kqWZeKAHmQGNFuqC3GYAmBDhZxU2Q/y7SVcGtGlvDyy8SfMByBXKBaMqsgZpgUHlGBvIPWolzftnWsePOz2e6GhU1tL5yIi8EYyGFIDih6y2Q=,iv:D9zfyYs7Bl0g/Z8IAgMEaabIH9MMVhLTfFMAjX1cemc=,tag:nnhJ9NCGwBQFVvyQCvlYUA==,type:str]
+    pgp:
+        - created_at: "2022-02-10T10:55:40Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQGMA80qvHKdsLbXAQv/SrrnRpaTFUrYLxINBYeMvqFWZwnM1i/0ykLU09zoWXHe
+            PzLQCp/m5dlUNeWtn5BVsP/voCMRjT0nOhapauW4TFOcrGdtJwkeJp31zacYUl4I
+            G1d1ZOpze+aXC+venXpynTwDb9FWleVsO4SXS5faRphhRsSWROQk+eMrwCJDLQS+
+            G/v7Zv9OyR5yX+dBqivcS2GMBEp3fB9yGrJwRRe/fGZczVO+9ENOyz+PGhiTtoRc
+            /1sHnLG79R19AaW/jrJT3/stkDItG7k9r4wDNcs/D5YtCOhSTowpj8meuWqLaLUp
+            ErQ1grN7tvPApXUu8kaoCTwNG/yVKyYzzJKEZ6cTqVYWXPIVqHIJrSK1+B1OadLZ
+            2idpaGcCmN7FwO8H/6bUyhWQ2NTkEHUh/DagwFNOODL/Yg0GDvsp7TbCQRel8Hvk
+            dxxoyoNQWyDkizXycp7GDVQqHtRONz0qyh/vztXbFqgshPVBpKk3SbfDFy4yUgw3
+            wDZYwF5sMlrTaJMuV6FH0lwBARlwnc2Wk0lvmHS1QCsjrl3UV9wtj3llfhQ7oc9l
+            RUCjUGdE0aExpC1v6vqNxPkJRhLImeHBG4JzOyA26+HLbyOJZxvj8Se2K6NeSG66
+            0wNUJhhLT5AIEretrA==
+            =fW8J
+            -----END PGP MESSAGE-----
+          fp: AF73310D7745761A4014FF8F12C8076653BBA9D4
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/clusters/inteli-stage/secrets/api-ipfs-light_t1_node-keys.yaml
+++ b/clusters/inteli-stage/secrets/api-ipfs-light_t1_node-keys.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+data:
+    aura_seed: ENC[AES256_GCM,data:bmcGymx8vpRLNfJGgdU401akNz5dXw4rqlTXY6CW3AiBjb8RqnbAuE758tiLJiWovZqR1iW6BjsRlI7f70K8R4Nyxfd3pS3sPJr5qUVcu78sKr4EyIsLzaviNt/qVM/UAPwg/hqkX014xH6EfQbWmA==,iv:GDPFbTDre0g/LW3ji+MfW61LKCULLt2HxtTwKCXYWt0=,tag:zthGSOU9cCcUeYf0gte0Ng==,type:str]
+    grandpa_seed: ENC[AES256_GCM,data:G2XpwAh7XaRGpTGfq5IlnVOcA6f66bOunhbomrG2iTLxM9HjP9lfFBdsYI1ppz3j1U6leODy1GN9fY0t9ygCv65XjWxUSo5f9tlBSfZBQhqvgRY+huAxu8PfHK7H0uERfAPpxNU7+wA78GJF9VpfNw==,iv:SFIH4qdB58Wi79M5dMyXAZFXk2CBYcme3lBocKvBeoU=,tag:AnlVk14IwsFVoOzTHorcoQ==,type:str]
+    node_id: ENC[AES256_GCM,data:x/oV4znHeLkaHU2wuyH4VRtuXQFB7/+8HiESBBu5Gau1VuVlF2yKmxT224FbTZBnnjWNOOxHXg0nxhGe9lJ7iY/DD2AjI86bY539BwnTszPEj+BmfUb4rA==,iv:nfG7eIq1e196E758qoUkoqgEJ6yPYkqzMMGCpGjwF9Y=,tag:t5cMdD9bC00m5eFfSByrLw==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: api-ipfs-light-keys
+    namespace: t1
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-02-10T10:55:44Z"
+    mac: ENC[AES256_GCM,data:wpeVF9fzrd+WEca2kgDBSqERqU3Da4ux9b/OlqBOMmXdY6/eHggBgmmkHnKgnuo9+a8NzH07rOthC03nfZKIDRlrGrDaD2AKWMu6kFVG+QhevvAsT5ILixyy9QG4vYYwPrwte7+uDtzf3DMUdWSUicKDdM1ctma6A2QxYvegDgo=,iv:cFssUWWf0DPGSQYpCbBe3xSBgbFe3mMyx9n/9psArVs=,tag:vEpaLpEKGFs20sKsRoY3cg==,type:str]
+    pgp:
+        - created_at: "2022-02-10T10:55:44Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQGMA80qvHKdsLbXAQv/TzTbvTs7nG9tx77E6fK1vmAWidrZ7dUQ/cbsyWkq0+F2
+            3KMxhWmHBNT9zATEdIdvO5J+yWt88njTx1ThywnDZMWIsFtsV/Qz4mx9I/I+rKtB
+            /SDmaKtVj4qxQUhWeZ54MIoa5ntBvj1Neu+1MsEU32Vv5LnJ9z4lzf4/NeHtpKEy
+            zT0ODKLqjPzU5uZIcbUvFrhiBy0z/7VopRMgIClB1U9gYWxSLotKwO8QlT28r5Uv
+            8h0Qph527fdHXkJoMNRH1riyEJVqPW5unxrh3PUy9BnE6NdzjPsslGWh/S2/eehq
+            fq9RdRQ9gxQApqiwUIxqKmMTyj/8b95vNKkzL9jtx+S7FVcgWjZsVyx7w96Gm/Tk
+            gNWmDO+RQUdIaw2tMSaTBdlCVqV1pvzbEdc7kUsUXHFat335SyxKJM+XDXIXQ72W
+            4hU0pxxgafLEe9P5rl5yIJPhmJwN8j3wuuy0UBoc6VpUgdfbikLUtZnxMAoQ0ipU
+            3Vmre5rHY/X8Zkwy/aHG0l4BX/dwBXzKkQ/u2cEDNV7JSyVAPQOP5h6JuWM49kNy
+            gvILwT2BH9eghSK7+ZuteZTD/KYoFwjGKAlVW8rSWgOg7+zHH6ICX8MOev997tef
+            4sIr40YlmUTflg3YblyJ
+            =V0ei
+            -----END PGP MESSAGE-----
+          fp: AF73310D7745761A4014FF8F12C8076653BBA9D4
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/clusters/inteli-stage/secrets/api-ipfs-light_t2_node-keys.yaml
+++ b/clusters/inteli-stage/secrets/api-ipfs-light_t2_node-keys.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+data:
+    aura_seed: ENC[AES256_GCM,data:wrtymRnPxBBwxIDtsNLK7LqWvCQPkGUyxQC0SFMd+/OYwI7qHoNejKLGbH1zvPzklwYauc+DBwkvOkxx6iVguVpQMr9tSTfzVOBcO1TL2QT2mthf4eXVhUeIOycrpxf5LgCYWDkDRqbTWHBi,iv:PyGQ1jFRpHs346dPXjreADb8GiTZJgV2TIXq/+0/pMI=,tag:6B8RIZ5cb5GYw7OkbQpwUQ==,type:str]
+    grandpa_seed: ENC[AES256_GCM,data:uGZUx9bALjyhCdgbP5LzHcS9BgC9dqUl7m3+kl8mySG37k3Q1T7m0kF/EVTjF8UddNjFFrm6alwFb3+oBvNenssIw/pRxa2PJBO9Xsli8v1dyXebG5WXtjfuZ14uHqzpsGj8oYMg2II=,iv:c4MF2YDmr1CYQ0PNw4/Ce+0oHQaoQ4GJLURrH0lx6/4=,tag:nUOypZt1ysIQAl2VtSTZoQ==,type:str]
+    node_id: ENC[AES256_GCM,data:q1FNyoFvCVBkDY/lR3geW3NQ+tvam9ls82M3l7LuhPrDdolsB9SGLVdnlguWMfUFOxasX30oKrgIXflJvjvnPau0hORzXDN7Kr2qNp4FupzXXobL0g1jNg==,iv:OG3uITW84Iqm+5mpYTW+8w9hy8Gj/H41Z7ONI5Nsy9U=,tag:tLqHNlaJMSIiMpVUlIQR2g==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: api-ipfs-light-keys
+    namespace: t2
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-02-10T10:55:45Z"
+    mac: ENC[AES256_GCM,data:Xm6eojQorisD1NHTJldjD2MpzEwwVpzZOR8DozKzsm6WgOr3fUOskyGkfRZuwU4aNuyb0Ru2Y/+7gWy4rzuHo/duT2Nj67M9wTMwJX97YH1XhecuY7bm6Q17vm+APEV+BTPYTGFgZmI58lwxyPW7A5aAHYcTOOXjX8Dk3VoVvaI=,iv:XGY2wp/QezUa5bQJLvJm0m1rGFLpZ2kXgUyVrHdoh8U=,tag:+EYMCaFBwBR7ooiBjpHvJw==,type:str]
+    pgp:
+        - created_at: "2022-02-10T10:55:44Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQGMA80qvHKdsLbXAQv+PsA4gM5BtG2q+fCyebR/jO8ty7gD9M1umu7GXXTe/Mo+
+            TW3GyxBLSs7m/22fUWKPwbU6d3iIPafB6jnjMzNRltX0qz27yjitBDSZyGcpzQ1i
+            CPQAi3PbO9H1cDG0tm+9E+WKehUW5vcNC3IGCqZV5kMzsVRzFvXIaLZWs+X+EcK9
+            EMgOa3xvEtmRr+7vO/yjdgzvesSd46AW7yGTuCuK7wyDzJTxX6m6jxwzqCuwu8cS
+            L8WHhwLsVeOlCo7o5FCOl6HNYCZHQubznhIb3dteWPStwSmF+07CEyhHGjqloAQs
+            7IZ2kKQYdQOKqH4t2Py6V1ZWPCSVZoGAOt5uV0Q9kAYWunbBGOwZr4JiPqKyVnVI
+            k02VGoq1wQptnwfckr3m+P7G8SE4+UY0uH6kmrM0FRh3MNdZ/w+c75TFGyyiUiDi
+            SjDN3xWUHwCHgSLRs+sBYZ/fvkqrsVwuuTER44QV6cOw9urKZ/I40WU4kZTso4yi
+            l6LieAvDkpiQC5K2706U0l4BvjNvMTN0iDSNsE3qRdsegR4rgfdlaEurqEKN+kzm
+            /EduRRO/Y6dUU1UPv3d6eZ11wAmpv080dkSoJjkWPA9GKZVdGdvQ2fZ3hoOGlBVo
+            sdRGlGaM7v/PysvRdpJq
+            =5XOs
+            -----END PGP MESSAGE-----
+          fp: AF73310D7745761A4014FF8F12C8076653BBA9D4
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/clusters/inteli-stage/secrets/bn_oem_node-keys.yaml
+++ b/clusters/inteli-stage/secrets/bn_oem_node-keys.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+data:
+    aura_seed: ENC[AES256_GCM,data:VplJaoJw1/cG9KauxFvrCgIkE+5gyqGEcL9A9SHGcbPwsbtxG8Ht/0oZY2jD5Dj2jiwZOduN2QFFCrV8if5Jv2XyT6M7HR9sOb3zDxqwHqmkrkKfDd1r3P41kjMw3eJzUz22XA==,iv:+fbl7iia4Qc7/lwE2V7lJcv2opO7V+6wVahHDCwQUrY=,tag:c3/CiljPbfrb9THVB872Ag==,type:str]
+    grandpa_seed: ENC[AES256_GCM,data:i1gS1wRxvZsTVguOHgy2frqezsC4H7tcRE1IQ+N+bnr7yQMjYy/Ms3tX9DKHzvMYAxHtWzmXXFhk9PnZYl2Z5kc8/N/6qoWSgBg408bUGC7pfGnlGwP5+YgBe/yWrQzAT22mpA==,iv:IOa9PWMMJWEfYvZIMPeVP0TAfwY8Ogpnu2kp0cJA4hc=,tag:od6rqI3tbEqXrHqqoIjtfQ==,type:str]
+    node_id: ENC[AES256_GCM,data:0Gu87W8ZIBPSlaMntHPvFqbBWkKpUMM78I7+NEI5eE+aEgZDfI/yV+y8d5psLoZH4xZF0WqnKmCZ+wPteWu2E/AXHewOsgK4Dvkf5BJPCNJUMsRMGRA3kA==,iv:RKF0BLuLrqpiol6kdAfo4ZpsvLuRWmg2QfDNoRme3IE=,tag:yNPBuQrmaXFgSEog/U/WEA==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: bn-keys
+    namespace: oem
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-02-10T10:55:45Z"
+    mac: ENC[AES256_GCM,data:BSyNNzEEJUr2PIHM6sZABJMVIpNSRNVr3w46rjDK978TKLjU3LY5WT98p9579btH7D3+eqG9XRiwVTZ6P68Zim4rPsz3UPeHrx0VoM+mYtSjvn9mQACBnt6iemOHQ6ZUlFnY7pKMpKSvhTSU/Ji7KRp3LL3LcgyYEnhhOEjaJoU=,iv:WswBponG/MYPG0idKZBi1jyUS3fdHwR07lPXhwSHpyo=,tag:D8DkPlN5p6e56CDdw5iilg==,type:str]
+    pgp:
+        - created_at: "2022-02-10T10:55:45Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQGMA80qvHKdsLbXAQv/T5Kl1EkwoLt09rWNXWqBS5UuILd52cl5Nsz6Qe7BkbmT
+            Utwh51AqEI/yFRvDaKJpl0UwB6K5Zjrl8jck6aMTF0odS3T09rEb8vjj5dPKQcat
+            v3lsuBdo0gtTUR7INDZMzJPhYYokd1mf8OlfEnrDuygrnPhYVl7ldrKK0c8woItq
+            mIeZC3OqNNUApNtaKe53kZkjlnuxStyfXYvcfZLJKnBNrPY/qoTPHsSYQhqP6mEC
+            yfodLZzbl7Q7/83Nqfpgt+NNTDUBDnBGvRHp0n7Todh7BnZo4Vs1CyUm1bRqiohG
+            90DTEbzfLk5qK1yEDhLnPIq+XR5MchHJKn3bqY3d4BxWpiYcrPCNjYVWft2DL3gw
+            BZwnBMhMyl4/tq6JIRd/rEye2w8pJSnnIDa1/R7fXHgiWXpC4w5HhbipvQom7XQC
+            aiEQCzyPLSqACnEKl3mihlzYema02BzJbeNqRe4SQA6O9s9D1CIaZwSwQLNV866C
+            lsVva5ERrvNzVTf6Y5c40l4BbI4q9SmHJ7cl4zsiA5ufBVdi85BpZrvL59m23reu
+            yFx7UCazTr1dKAx63HYlFXUjPLFvfdqLhsI8OYCsLMrjNeJzYeDymvHXHb/pYMaX
+            PGeHxitTBztwkSyJJ/zt
+            =5cDs
+            -----END PGP MESSAGE-----
+          fp: AF73310D7745761A4014FF8F12C8076653BBA9D4
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/clusters/inteli-stage/secrets/id-light_oem_node-keys.yaml
+++ b/clusters/inteli-stage/secrets/id-light_oem_node-keys.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+data:
+    aura_seed: ENC[AES256_GCM,data:Uyck/ay7Fvs6Ms7z6CepnJp2hBtnjXoz9uRyo1/Kja8c1YzluBDDXc/UR6df6dtsArNgyUFGcbgm/1zWub1mDkgG7YV3PXLdsEs+HfkygbzhwKBa9eYTL5Xzxb0jKKbi9GsugJtCXFHWjQM4,iv:7A62GpoFPcdhh3FiXYqHiTnrg0HjJpK3G6MAlcWV0ew=,tag:OSL6h/q6oRRt4JmyMOeA3g==,type:str]
+    grandpa_seed: ENC[AES256_GCM,data:E5Xiw/nU8X5GjW/DqJ/+S44tZCXskVIKjQHtmxtdTvQ+MVn46zyOrY0+5cC6PNRI1og1Ve43mVyCNc9rFc/cB3j0ZfhP80f8Xp3zF0+MwnGlUkY9DjQnRT+Q1REoaX5eMvpjstTzy14=,iv:dpU514p6jZKURh7GJ+dE2XijbXZxX0fL5WOiNc24ukQ=,tag:sql+H21FLhE+Wbxdx22eJQ==,type:str]
+    node_id: ENC[AES256_GCM,data:RfUKjBOSekGtpRU8dce0Hg3CvH5sx1IrzIRMKl8MojYsuQ6FzcyuVJEV8jdnSEVZOAzSMnpsk8r2h0Upj8AUz+3bqcrIiCqEVVVtdFEvcuAbwZGtgzHwFg==,iv:5BqFDmCAfBlbCCfuWJnokiiWy4tGDpxvwBslWZwB4TE=,tag:VzFHF8f18zJ4Q7q3vF93TQ==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: id-light-keys
+    namespace: oem
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-02-10T10:55:45Z"
+    mac: ENC[AES256_GCM,data:cSzptoo6C7x9TJrimgR41d0lyMg4ilYxdDt8A4l4uJF+dEoc7Z3C++fKDbov3l/7CmYM+NmA5SqLyVzS4Qv5xlMQWvKbwtZTisYX9XWD4mJQJdalbVbKToPwWhI1qjEU5xW0CYPq6NomWCC4SQ9DolozDpJvCRE4iTp6NCgDkHc=,iv:Wc4bdUdQK6Yf3DR0i4E1etFtMRf9RZeCXRYHOv8od6A=,tag:kpgBMxT9k3f+sJ/xbXbxrg==,type:str]
+    pgp:
+        - created_at: "2022-02-10T10:55:45Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQGMA80qvHKdsLbXAQv+JerUsJDwz75VRe9wAeQvGFac9XTMblqqaioj3ZMX1Al5
+            tS/Mnc1R1eR3b42S6XWKmBRB9UOwtehjzuwOnc3bDzD+BbLx6EZh+1AuSCsU/yfp
+            rb1wuobIcFIRiQvL2oFAeZyLjqluoO0B71a2xR1GYMdPLl+78xxcrI/Xilol6fDO
+            iIIY7OPTjtCOaC724v0W3xpYIRIxzR0m9MuwvSnYrkVSmsWbkhbz0HGQqEjhVrtE
+            90zM5PnroAx+PM/LjA7DnMS34iJ72bwUlfOOm0J6t6UmyU8hC100xUozQx2RRbxq
+            i1+xnyNy6UGxZRaI+vjeTvx23xEXzntdYfYpTkIJ5LytVYBnvcY6VxdwnV8Whh1c
+            cOEal0EsC7jT3ufk2WPd9c/f6oppJlpSFKFhxwhvr9fCyPHJYqbP+IhR063Jx+oP
+            Mt16CJSTw9MsF14wZewUVBeg+ba1zTJSLYOxaHZg4vOe9sQ60Z79eqXNmBN3Y08r
+            NgmKDyRDU7jPuLMmlZ0r0l4B7P0lzwyl4VHSG6vPzV4xIkClmaVXYg799aw9SEya
+            0FGgQm0bCXkKKhjtpEUKs1357mtqhHcgEqRDwVj14QsclqSVUqdksf9c1mvBbE2p
+            Qef+O04nvtDpMmoB62Wz
+            =3fZ9
+            -----END PGP MESSAGE-----
+          fp: AF73310D7745761A4014FF8F12C8076653BBA9D4
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/clusters/inteli-stage/secrets/id-light_t1_node-keys.yaml
+++ b/clusters/inteli-stage/secrets/id-light_t1_node-keys.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+data:
+    aura_seed: ENC[AES256_GCM,data:FUDMEhKGj4dP01U4JoFI+ebIsHjoN3K7kTVq5jTU8ROxvN05LLTd+Ww7ratTuDYBQeeYLkHfggPginpvRuuo+LML7IXJmJtgdpiIYWa3UQ2l2sdpEU+5KY/ywGsTIzP+,iv:/sGaBhNL7eUHDo8Da5i68NIVccgqnxk92WgM9fnemBs=,tag:E/NpXSF5bgeMcU8cuQ/5qQ==,type:str]
+    grandpa_seed: ENC[AES256_GCM,data:0MF7rBNzt80AG41HEOwRiXxY4szrjK0nYksgV6GpR3InP3V8J4dZwursEqwd9BHd5dErE5e7kEDWYUMt2bSHnvToR3sSS6bJpE6k1Zfu62nQY7/nwASQIS4Kzv/mqHiwdkQdTA==,iv:dHsDvAZ1e71AIz3UQiHf2HVzSfBxWk2plNwcsAyCj+Q=,tag:4dBxAa2J+lEfSQM/K0DDKw==,type:str]
+    node_id: ENC[AES256_GCM,data:AHxcp0epuiu19nWkiAd4nEx202TvItma0rrVGnZRigQflqfUaLEbSYIK280n5NUQAqKu8Mcs/BUqCq+dfoqZsuZ/kB4luLiNbfXjA97zCMfZJXlK4lm55w==,iv:DwYESG7x/7Fom/1uUvQGCPfxllyotfu9ji4adApgVYs=,tag:AaKGJRoVtbqMUAqu3BxXaA==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: id-light-keys
+    namespace: t1
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-02-10T10:55:46Z"
+    mac: ENC[AES256_GCM,data:O+tZS27jFYG3kLpIiIY2RZGYaPdmy2iDQru/d7YMPB0Iwfa0cez9TC8Q95HvVcDtlNYJYzkFRK29RCAW5t74CXNDg4B3gqIEb4thBPVnrY7k+fV8YiFcoS/VBKhIYH0eNZwK3+tgNEFMGh74786RDlWsnlKOAvwNZErIvp6C7gI=,iv:NObwx4NoeDAVFDRJNao59RDKKP7sSxUDZTVJceizGt4=,tag:DQUW24bDDb2PB0PCF/gLwg==,type:str]
+    pgp:
+        - created_at: "2022-02-10T10:55:45Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQGMA80qvHKdsLbXAQwAp8yVGkkOZ01Zhm3ZClFb+ngPTdfN9XYG/zLbcHrDBzqq
+            Ik3vHycFCnUjadO67773EtQbTtJMPVK5yVre4MBJJSVWpNJ3qx/h1ul9vRF72mOT
+            f3mCACIjxxOgFC/Uh/fAwYCwfSvuJ0nYR4tgvVtEgt3PDZYJvCtanLqicM/hJCMi
+            Ac5HdZ4IllE4hlo6DvnBv4Y8M5VhPJjrbKkZEQlnfmOrPzpgR8eKSg8YBaA5F/Gj
+            oN4K99tzwb6HIVB05329L81vg3ix5O7SmmGDPAlo5CJi9FFgVrb+4SGVugjNX6DY
+            tXUVCjTzt6g0ueWgBIS3ExcUwUB1F73ZHaViGs/CZ9HvcbXflq9uEKZuHKOlYWbw
+            2s+dIHwx5zzL3NzZyUfuTsOOzwdnTZUs4ev58SHzhLtXE6lf4jdIEhCbisBw03Qf
+            iqYVoKZbtA8MkrWgnkEFNTzNe1AhYssXv7b1kbpsk330yVIZt0t2Wr3LG/XPtFW5
+            cT7JqI30TsAPDySejOCQ0lwBOlwvea+x6WXcXr9d1lrloKRjND7rv0C0xbOJzcag
+            ELSwolHPSXsubfqkZmlADXpHvESPdMbU0UTMH1AvOcNiw2IMOTxnPIT/BYNmVmAu
+            laP63oPKzrv7c4P9zA==
+            =XLUn
+            -----END PGP MESSAGE-----
+          fp: AF73310D7745761A4014FF8F12C8076653BBA9D4
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/clusters/inteli-stage/secrets/id-light_t2_node-keys.yaml
+++ b/clusters/inteli-stage/secrets/id-light_t2_node-keys.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+data:
+    aura_seed: ENC[AES256_GCM,data:UvYmMlAt9NxNVF5DjiecgDjSafDif4Gjoadeb+HRtcPYOU+Sf2qF94u1UpBipLuiFaoNS4p3tEDXppLEbZFZehF++F9p56RY0aUJ8Fx9CVEgFg8yU2FH2ynOrSdGGz8LDVHAjw==,iv:+FEDukIbpbDe7A6kuIHifR1B1JUuIA5dhfzSMl1s1T4=,tag:s1RWoUhzoqD2wHuKtx92PA==,type:str]
+    grandpa_seed: ENC[AES256_GCM,data:mjq2U+1YP4+2Q+ZFTrXhONW492eLOedSF+VJUnTOhKQpdgoUTbj6nPfMDDO7RMHh9d2voVVk8tBRM1msV5+UiiUWt+gdTg4wivsa62VUR727Bb/P8167wFP5PL4xEs3yJsd4BAZakZTh2zq0E9+D9RhhJB8=,iv:hQhHqyd8Kd/hX437p+znKUU2Xe4fH5mlpKgBIut4s/U=,tag:eud8uI4cC1uVTPS2MlTmjA==,type:str]
+    node_id: ENC[AES256_GCM,data:nF1ESBzm66Oz7WCgg+W0h9Sg2fG38HusbIKqp8Uny0ToLuthnviOinnpBEiuGwyA0ElJHwI6rcujv6rCcRyKSvH2x3ff9l48B3CyHv7uCRkfeMFr0ctinA==,iv:ANdf1Q+T4Z1gNBs5gIPQIc1RxpJaUcWxSYg2LQCLG5Y=,tag:EHQh/UGGOf2AJ2gajoPNww==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: id-light-keys
+    namespace: t2
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-02-10T10:55:46Z"
+    mac: ENC[AES256_GCM,data:B/51JTBpqI9A80zDbFMgqqlcs59c9tow8QI7icm2NSi6I6mwrWGMGbkPvv6mpxaLD+xjpVhXUAplq9pA0KAgJ+umdlXWKOOhEiUoIi10yhn3Airdyarg9hNibOCwu8LB8hKFrHL5ZFgarkC3iSWCskVJRnxkdejagNjZI5ErgXs=,iv:MtupZWkWO5snDvJL2VQf2zcF+ZcQTsWG+rM6LdHL3eY=,tag:TFwLbxDYc3q8aUyLZNDAkg==,type:str]
+    pgp:
+        - created_at: "2022-02-10T10:55:46Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQGMA80qvHKdsLbXAQv+K2113cm/sw2LCa85WuewRj6c1L6nq2iaHMCJZT+iB63/
+            rZm/3Vk/8vGET1rMVwSfLXpCXpex8Q2TMv7FNnJc+0B9uujBjvDKnqepd0y9LKTD
+            sJWB+Lhr4AC3BlTxPvhNHAUAPTddiZRq5HTJKpmWNtEVAV4Vx+BfFJnTzhabAr3W
+            3cCXoF6UBWMiaxNH0L3GkEIU2TTIEFcAIjGsmKp0sZV6YzZHsSc32YZfMHdsF787
+            5mcVxBR4J8CTVOse52cpOnlvePbP85zb2MG/YAlhI9AmbKZ3y+mWyJ2VoNZd5n7a
+            dggdbMkX3DkXgMxfv810p/jiRrdOHQ6Z6aOR0c31vCLlKCw4nyHjQrp0Q2otVqF9
+            cql5sBky7s1TtHztlkNxQwd/t41k37JW+k7Xg6qKG99915MrRG9ybiS+iclj8YRQ
+            lxF+CmaV9WgWXIOfg14uXJj4By1B+MnR41wYZ+CmtrNseHrDAo7X98rzbVdqH5p6
+            FYaIvQVT3AAGlh1k1D6S0lwBE2YL/Hy4UIQcvv1bZGkIAGZwNnOtTJNgoA/+rGXG
+            fky+U8+Hrk/6GOK8W/h4K3xDDAL+l247dRSB00gCWOaEpeftx0NQKv4sUK4WpASf
+            0xHWMe3EZWUVqkjyrA==
+            =YxBN
+            -----END PGP MESSAGE-----
+          fp: AF73310D7745761A4014FF8F12C8076653BBA9D4
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/clusters/inteli-stage/secrets/ipfs-bn-light_oem_node-keys.yaml
+++ b/clusters/inteli-stage/secrets/ipfs-bn-light_oem_node-keys.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+data:
+    aura_seed: ENC[AES256_GCM,data:6B33GY+UMihHr33T5lPkYsDjDHaYBe6+Eq1sKtgBpr9cLAcffNsA2i4e+4p8JTESXSZSagbPg93Nqyu2f1CCR+ru8CIwbT54rlBvTYoSOGA3G+FCUgfjuGJpsud+STS5UAYsJkpbVI2JzM/V,iv:qY11R64nngtri8bk9SIokYwHOyPgGNkyfUi5GHYT2Tk=,tag:g5rAQ/g2eSobtZ6+g3YpOw==,type:str]
+    grandpa_seed: ENC[AES256_GCM,data:ntSshGpe9Rij2LNYAAxTEC3p21rBhr86Fo88l0Va8C3GXd+6S8VMi5zk97QM7Yrcgp7r5FHN4mjffumIR76weNB8z5UUgazs7H90S7+mmXL8R7N5xThdUcOoAufurKfso3dyeQRkyu0=,iv:f62uIuJMoIlJ1NnPxj4qmB8qMH/qeA92FUn2+haBgBg=,tag:fUoVjviH0gBMHoDexVA+Uw==,type:str]
+    node_id: ENC[AES256_GCM,data:HAmrrgX+F4cmMiOXKKMa6XrTFCN7ospcEvZ1yiB9/H0XzUJ2Rhk3R72CXikszd+3H1MdwasEt4XHMR6l87SAfG/qNqIMbkVkdEWjRb5dAMTXKLS3fB+LhA==,iv:WMM45iI8mQNoXgTRGKKi+bwZgVYXwDbldILP5CZ3WYY=,tag:yzgmVGWoYVmD6kQLr8duXg==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: ipfs-bn-light-keys
+    namespace: oem
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-02-10T10:55:46Z"
+    mac: ENC[AES256_GCM,data:VifSZSTw/QOftOY5jHh0wK0f4WZ1aQaMmUJwZMrASD+CABiNxee4zs6VmNoq4eNjIuXPvN56gNcinEmXngTAKiJB/0tdkHdavHMNVpATtOZ4d6Py/dy5XL/4x/o2s0o5zqkEqLAwqLFdI2chNSbOStTY8ueeNmxE36qA6yfo0UQ=,iv:L6HkjUjQrvkTCTsjmHRxZ5WvYh2Cntt+20VF9mXpF24=,tag:zWTFk7Pz6ONGJtv8EeyhDw==,type:str]
+    pgp:
+        - created_at: "2022-02-10T10:55:46Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQGMA80qvHKdsLbXAQv9EWX/2CloFO2LpV6MTV+lHK++2viW8oweZa74E9th80/E
+            Tc1N7x9NpYpexl5MuY/zBkJp1dLrt4pEyp+M9EuWJTgmj9849Fo7dkleaui1gylS
+            E+BUx+3icJszWxw7mty42jCyPUgLnOBQZNLFziNzN8Ejo09taknKk6XbBlZ/Ife8
+            z6f/qmIDgrqYSYCZ5LTQ9Iq9qDT6gxCtPqFfu+yK2PnSERkeuy26IaUxJM/KuxDi
+            z8DhSNkwZFgdgtx8hfeho9ynu9jUTaNPBM05qM4ZHRtJgHFwV8H6Q3KUcztOkkB7
+            taEmak8oSJRfci19G7dslrIv9NQny6RJTjZpVLh4ed0bYM5H1yP4mnAftWYwhIJp
+            5fKkdMrCdcQVFnStxgJTUo/gSAx1r15kD6asYG+8EWYaKzimy32TTmwtlhrBgqhb
+            kfEpq5gc83QBlfUniMzlgJiLXLx/tH5JUnF3DBxC5VDjDoNkJlf33oCXP9ky5N3Y
+            T0JpIhkD46RaoLYVX4Vl0lwBkveIQSfBH9EGz7czKDm8EcG6FHGwEy14fN2W5MO/
+            a8Xo2ku1U/y4d+56duwkrTM/aQ6tIb+GpwlPFcz/ckh6r8DPO3JJcRkW/RLU/6nP
+            dcYb2RxcvW6AzJM7rA==
+            =uiDL
+            -----END PGP MESSAGE-----
+          fp: AF73310D7745761A4014FF8F12C8076653BBA9D4
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/clusters/inteli-stage/secrets/oem-0_oem_node-keys.yaml
+++ b/clusters/inteli-stage/secrets/oem-0_oem_node-keys.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+data:
+    aura_seed: ENC[AES256_GCM,data:Ae6S4BWN3ujombmlMiCv205cFjFYBpLQTvlxTQqCQ79vCGW1UYrhy1xRsxE3cB7BxBr0h/P3DV5LKjzvh66uYDoJWDrx+QG0vrU2HrIvphXibJ7QMKApKkSc9vj6Bhbc,iv:CCK8v/JWczObpS+Ng0TGaYVlt672MUKLZwl6uKaOyjg=,tag:iGbIqkUwhai1w4/G+4/7sQ==,type:str]
+    grandpa_seed: ENC[AES256_GCM,data:UF5kntnRQ0eqGJwpBQUZPPrD5p562KLc63UdeB5G8R0sVSU4KR6AZQNBA94N1lVdZ00Vu2Gt6O6q5KZbc+86wMtE1HK7Pn00tEN3CcfaoXcJEWmuQTqb50VW2/bxEC40ThqEn7u86Ds=,iv:iPGQOWc7B9mVRw2quwG28qpG4wA6NkghEO7DOTkvYmg=,tag:N71oCxPb4Jg5jS2PDKVk3w==,type:str]
+    node_id: ENC[AES256_GCM,data:Wqap6I5hwniBIMU8Sc6yr1BTuWJDmmneoFY4uzr5+291peFTgGiI4t5l/trwTqbXcoSCleZaxrsGG/qIWSLKL5fq2PuRfmrSBX/aVOlq8ot3U8VIB/9QtQ==,iv:m8ERG0lDl7gHmZepwLAQBFzUlDk5PlE/M9w/tuMQ3O0=,tag:7fnWrKTSqQTeKnMxmi1AjA==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: oem-0-keys
+    namespace: oem
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-02-10T10:55:46Z"
+    mac: ENC[AES256_GCM,data:N/k0pqUnTK8Uo4gmIp202iDnRrFCtKwb8WTqPz9jEKCRgoagVYZt2e7eBOGMYbQegxNx9oxyx8JV2LO3v284L0zkp6HcwQKUyTNAEle/jZn/vURwoe6sdMJIhsmunwb9uEyPAO4SJ3t5qMw9J7GRuXodP4bUUeNJkmf7HGxJWAA=,iv:RGVKoFTLXVXE1a1mGXkDvfArArLBP9j0LsvaoTe87fw=,tag:4SpU8XPUKMZNoud0randAA==,type:str]
+    pgp:
+        - created_at: "2022-02-10T10:55:46Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQGMA80qvHKdsLbXAQv/euwL9W/sfgd4mN3/3ZOeDtRB0uMiodQBlxu0R4yV6SSS
+            eDuIAezDa1XcLKEjtGfM8AZwFZ6mgH/eN2vrjnqcCVKBzBa6GyOlT63IC0t0N2Hb
+            O9LBHdHhqe73T464bnlcuX8aUG2NQFmQs9Dc3JU26DBdFeAep5ElMtjpdT6bmxjX
+            1VFOHMO/4oWFH+qCz/pk6DJL5V6cUxboDJewbHvxBoU6t+OI+8beH5j9RL93WVlf
+            fpTMrM+Si4hIcwT2CRhhZPiVeI2r97zoCH8OKHJ5cm4a0SCBILdBik0rftKVzSaW
+            iNcxdT9aMKB1WG3p6Zgk9Pxnlo1ywUuj8Xe5kFO9g+aV4HAe4UOLmORZZkfjMXck
+            qbQt8bLABkr9nrTd8lVyvmyXxKCSHcfandZBww2fuqFRSd+q2prGIImKVhFZ+F6p
+            mv4Gp3ActU71c6Aat3XmLP9Jg9ca/5Ra7BReSId71lNOcAvqDSmgSz0i8eO5ngeM
+            eW/RcmBoyclSiXfoeIX50l4BJfi+uJMUBWyO1Y/krWc5ou4Ydj4rc0DYZC4wdcE1
+            uf2wa5t8dATV3zdnyxWSwu5FeFAoX6B3h+/P2T9xPVAFElNWa+eEwdVgRKYu3z6L
+            2wOfVwe86rmLIs9sjCXj
+            =4Yl3
+            -----END PGP MESSAGE-----
+          fp: AF73310D7745761A4014FF8F12C8076653BBA9D4
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/clusters/inteli-stage/secrets/oem-1_oem_node-keys.yaml
+++ b/clusters/inteli-stage/secrets/oem-1_oem_node-keys.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+data:
+    aura_seed: ENC[AES256_GCM,data:nbYBkj4JsHi2ZgGVVCQuqzjMRKJj6xvjOwI3rdMLmawu8io6PobqeWwCXlq2XWgg2/1pZBqdlo0LO3FrVLtUYrhDMMkWF03i47S+3Xn4YpOk9AzUaDJsYFuUsHbuzOSgx4iJ8RtvakM=,iv:JaIFQ54wYHef+tbul+glyedz8rFaFFEMrUCGq6XzLp8=,tag:EayZnjp7p5E1ZJBQD5CalA==,type:str]
+    grandpa_seed: ENC[AES256_GCM,data:+Oc3BqKyg8jTTVksWuzXkRoD/FmYdXc97s9VBLATJtRo/7wa9LCgu6QkGziAYcreUIx1UYSSlF77eHUvojaWiIS/x9/NMCjGKdrcfbgwX9U1gq9JIEvXKbfY++P0xagQZZbHeZr92ho=,iv:FLgetdVZYSVBFExyZtgFAG6BpBI8rGeLhMsQxXSCTro=,tag:/nQMsoou0Z+ph3kEp6b02Q==,type:str]
+    node_id: ENC[AES256_GCM,data:+Z5e9keV76W0aq5YgktUhP+R0rt0hWPuCcBg/hgbDzBHp2rFPst44lGHcTc2tgHu237pDxlZyBB/nP1b8+q6szlLIrn+6+u3pii1n9SfcN0LxHqZhLcQeQ==,iv:ieoVCZ9nbRQv+xV41exyxqXO2jf3NT7NxmgpCUD0lJE=,tag:pHVH/8QE+UfmrPxg4oZgOQ==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: oem-1-keys
+    namespace: oem
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-02-10T10:55:47Z"
+    mac: ENC[AES256_GCM,data:vkhwWGrVMiTHXmiBAI6Osztrpy/VnZMNHEr1g0OVzdAFcKe1H6m/FGxtDLjXB8oIXFZkAF8RCpr8ZaegBPYzLr9Ez3IaiV9TTDoTL4QpHxvYZi6znbrK4M7rNkA2DjHHU7jvBaQZMOzKC2IYXYKZM83yPni8gI98PVfUpZQLdJA=,iv:FD1KrnwBw/BIa0KUs1a9tdMrfVySwnGDqH6MLPSAMs8=,tag:OfU/hw32D71C5bKrLHyPhg==,type:str]
+    pgp:
+        - created_at: "2022-02-10T10:55:46Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQGMA80qvHKdsLbXAQwAm7M4QdxRpzCvuGkJ3AmncMzSbx7/8LMJhD5QwdCOlV/Z
+            Dq37EKHPNKtld6DzsBe2fsTjj3MqqIWwUX6GVVuimqU3Qzei4cbyjzIkLKoWY3pV
+            upuPUmmVi11THYaDWCflBNxX29RXUZ/SwWTgo2+aBqypC65ywQgU/vDryLb8EH3J
+            LW2G66eC4E7zv5XZ2CTDCUVb/E6ri+MNyfo4TGVqverk97BBFsfWQXZPZqIlLbK/
+            EBXCs79yqBNBTsQLXvlGkC7NGV/zt1EVfK+U9mDAphtSE8Z2OtYXn05XMxJqx3YB
+            /koMb4YT8NCFhjPKiRGSr9iznxj1gjMT4fOpePYj2nzhWmdfxChI+c/ALSV9IEGa
+            HV5ubo5RM3nPZzfp5xIJ83iRdISCghdXHUgjs7MZ55pIx613RjUrvlk4R8KVhRYF
+            95uoLN88LVvvAeCE08qD3SkD28KtgtZQr/GMeBy/tNTR6Z8jgK1v98WpRn39SVI7
+            DgI4bun6hryJm36CbaUD0lwBEtwCQ2nTDLZm+kRmR5iaA6h53rLNNCSHrBM5kyFT
+            Hoqu9rxykYeRBhwL/CKZBvCb3QzjbKRHszt8KRKBC+T0yCMQPsT3zyqRv4+D2sf4
+            XmEAuwsMd/zaLuGlkw==
+            =P4yT
+            -----END PGP MESSAGE-----
+          fp: AF73310D7745761A4014FF8F12C8076653BBA9D4
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/clusters/inteli-stage/secrets/oem_oem_account-keys.yaml
+++ b/clusters/inteli-stage/secrets/oem_oem_account-keys.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+    account_seed: ENC[AES256_GCM,data:lnk1sMNgg4n8fPD0jV4vBzHrT0RnH6NSk7Khmydt9aImSDz9JbbdRP37t9y9BfxyrBSMWTdsCrYz3jg4cwJEBQ92Aqrj9pADcdbP4XBuqx9wBj6thQszJqMQPa8=,iv:AEPocCIMV4BxGn25AqiDGr45pk/XDm+9GkAX4xVFKKU=,tag:rkoa0kWqQavYOoZ8JuzYag==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: oem-keys
+    namespace: oem
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-02-10T10:55:47Z"
+    mac: ENC[AES256_GCM,data:OaQH7kcYvX1u7y1seRHWGYIggIj3pcq7eYRleSdaRRpGMJt22hQ7tvfRi3M4Qbm0R8es8hDD8CUjya0BxgTG6hP4UfZ66pBlhcvi3Nryg4eNaf7MtO4mS1N+QhV6Z09KpSmJp3uuHxIxU4YKIfUcnJD8vz5SwAtJNEanApCDBr4=,iv:RqbtWVIFQpcjGYKbDBwqcDh/6SebEA4rRPcxMAWcFlc=,tag:ZfWnPHTelmk3K5Z2mqJu1Q==,type:str]
+    pgp:
+        - created_at: "2022-02-10T10:55:47Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQGMA80qvHKdsLbXAQv+LfbwP+ppCXVmcs3/yoC3zQ5imobrFAQYoXkRVjMjkxj6
+            8Et5Sn5bkuDttfqqqoASSgjgIyVGj+HZKjirgW6upVi5xy3P1pg4oXHwvDt0jxS5
+            ZZeGU0cI06ob5yuiZshV2Hm01g31qp1B1vq+UT7EydQMWWRw2w9dp/Lu7t7iY+uj
+            1jAtiBJ1DjjrZwSkX6AFSRdf2xmJm9LwBgBalJ7wvcKYOXshg1stOCQRHQ668E/e
+            b3y4Qr1VDS/bOmybOp1825T2lAMPXPEtc2kqo1gjbuhGweJAQSUmLWhFsrnjLhoS
+            DMGqoPUtuLbc48Ngbe+2YiF1T0zos7zXr0x2EeTm3dmyciPvBwwd4oAXuW+zWy7l
+            uUEr7zv5+zdvi394gHvZMCuaPc9QItg22Et+uHViJti1TdWWBJhn56lRyYr4xqWm
+            PTOiB27GoGxgdI325M3CiFFaeOn7cp0C/hG/UPs7GfIiDXp0oBnhpmYoRh8udwWR
+            hCT9kciCQ3koxFUetZD90lwBnPWQrIY/q8Uh4mnfazN9/f5E0jzlu6b2lexN62jS
+            oz67s9mzBoNd1O+VEHDLpPDr5rc7jyACBB63poq6jZrVvjQKW/J8JHbqkIHgyPDz
+            wpQtW9TZO2aZRcS+MA==
+            =mdAy
+            -----END PGP MESSAGE-----
+          fp: AF73310D7745761A4014FF8F12C8076653BBA9D4
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/clusters/inteli-stage/secrets/t1-0_t1_node-keys.yaml
+++ b/clusters/inteli-stage/secrets/t1-0_t1_node-keys.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+data:
+    aura_seed: ENC[AES256_GCM,data:sWco7W9M+C0RhbSo5ORZvtqf+8n9pUSi0kl0noxs2KFclC0n8UENv8B9TdSLTtPwq7skN53a6WZx+k0mkpjFv89VsxSlFp2qQ5P7brrmY6HWE/NPoiFc+bFPEf1CaBi4ieoUfQ==,iv:wKOWN+0wraEUgcjVm8uAeEXgrBCPIJ1WL7CD94P9mO4=,tag:ZdrXg1wQDQ7ZebKRvIs4OQ==,type:str]
+    grandpa_seed: ENC[AES256_GCM,data:KJucr/lb3qAyZjk3U6jJwu9PI3ok4EkaR24I21b/34mzomeLxLjWJzjxQ/l8nF8HCGs2DYPDXjSuu/LkDLZAa3xlbD/s3rGh09stvWBLsjxfOzk6yvBWTxNaFZDVlaOL,iv:XOGNcBm7GaLlauLaIXSLrQon7076rJ6xNk6jqvwhpOQ=,tag:HpZxtymKzg34KwQiU6FTPA==,type:str]
+    node_id: ENC[AES256_GCM,data:Ci+X3ai155RGzUppOFc2PskpgfPdpBUOAGtqMXbSg3qA5IQwlvkuAmtBeU8FXettLQCBTooL1gETFhxTL7EpBSOzM79IMw2dA41GgFX0KqZGR8WCDnL0MQ==,iv:WRGjz7m1cf9WXAbXLwqC0WvZbwNYvLRxcniMteXzeb4=,tag:8g+jEGGofXu6razRyEhXtA==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: t1-0-keys
+    namespace: t1
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-02-10T10:55:47Z"
+    mac: ENC[AES256_GCM,data:F4XtFrHdL9WWiYo2wkPjpnjC0JFZAh3FkqLp3FvwTBnvZtqMo3h8CZS5znMC9Gr6uL58Wm/ySdroRSLWbJrupUBlWmdUvml9qPB6w3G49EC1gtaaAQx520QCMihAeddZUiExFXaxLVKfSxh2YBoL2j0G5wNHJftfq1cNicU8pww=,iv:9R4WVlaYP3hPYqEtgZOE+0V02ya10mGwHQ5NI2osaLo=,tag:0QZbTCWWcxalhfVvn/+2WA==,type:str]
+    pgp:
+        - created_at: "2022-02-10T10:55:47Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQGMA80qvHKdsLbXAQwAqDLmYOkxP31osjJGkJQSkHIyAWPTXLnkkg4TsYJEGqbI
+            Xcdhc1bT+dT26CHAcJ7zYzTy5kmxTezQ+TpZS1sWfJW0W86sOaKxUEwAmjpUu0XN
+            KYFUleUljLVza9wU9Qeu8bhpZygj3cqSSiBSsLYVQI3+oDVbneKn1pVP0RsWlEuz
+            JuUT9XkE17zZleYVersZUAfrAqJlXLHtIaFUa/7U/diA5Y+9q+lvi5Rbc3dsFh3p
+            CthTGo/6GugIre1U3zU1raEM89jt76K5qG8630hWc5RlrArGe7a3S22BrJasSEvM
+            XEWtGbF0jSm51FvFglAJOPYaxFptFAjK0IKisVYS9PYta0d0UPuo4mwywewlEUrE
+            58nBGVFcpG2n9ERyDxYB484DKGWmuvTQ1X2Zc/vwOddIkxzvRb22u8wc75sJy2oe
+            UAfG6B4vb6GxTqd8D9wqcb7uXI8LfqWaCP4UAx4M+fMleAWil5Uqq986dJki6OXR
+            j7CMFtnZNbeISI1MixCH0l4BtqWH8xzzzreqcA1Kb3ZvPerFXiUtFoY+a8ELTYJy
+            17yuGAlXt2WVVrq16Hlnl0s3kCkYZhxVM8dtNK4ESmuH69EvKwEN0/3zBDW149Wu
+            HBOqzDph2JEMqb7DMr7P
+            =YmEV
+            -----END PGP MESSAGE-----
+          fp: AF73310D7745761A4014FF8F12C8076653BBA9D4
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/clusters/inteli-stage/secrets/t1-1_t1_node-keys.yaml
+++ b/clusters/inteli-stage/secrets/t1-1_t1_node-keys.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+data:
+    aura_seed: ENC[AES256_GCM,data:r9uyiCRonYUJpbUqEq76iLpO7L+MZ6gq22DHPWjZhJEIjNp0Rx7JCJF2h4Zw6f3QF/jqLRE6UJxX7KxFssn/RuoF3mZwLFsw+dHkgeAyGFvrAsB0beg5IU2e39DiL9T+ScybmQ==,iv:i28UMV/fMdC/MeEDFyuc32b4GhW3qdCUgiuxKaqpyLM=,tag:O62IZ0fQlbOkCypUV+32pQ==,type:str]
+    grandpa_seed: ENC[AES256_GCM,data:ZKnyKVDQjSpTP0vFx8iwngy999XN8SRttsNx+nROfX6LYf68NYh/XTbl5toV9YEMq2BW1vz5dpG/Vvfxh2FaKWuV8cCuCn+EyxDiZGlWq9hsX7inn8WKDNMCw8VQCzFT,iv:78YIVUY7Na/UJ7DIlhlAtIpyg1H/Ax2bKNKpKS/WqoE=,tag:a6j+BB/e2SvSsMc0f73Ong==,type:str]
+    node_id: ENC[AES256_GCM,data:X54w0d/4j7MlunE5mi+LnuMfBJgk2J7UCwJvkHqmUwHjKAI2tZio1kzQ3ByTBFjHPDJkkLZA9abT/B5WixY2J9LAmg8TxI43yFzaWR4wL4DhUb0+BYP4rA==,iv:jEyqa47GdcqCjPz77zog02AWyNgMrFJsnEEESaAD1BU=,tag:QCOzSU6XlnwnCpbnbAV6dw==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: t1-1-keys
+    namespace: t1
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-02-10T10:55:48Z"
+    mac: ENC[AES256_GCM,data:ecDl16OkSKhYSe2lWJqPK2ceTwdRWHsB/+uzbNI2Eq4zWjtcFmWovvHxtXsxom/48IpZTq/UrltJKoOFl+QsGGr9O5yZ04PnZusjdXP6REOh2i5a7kBmiD+c57e7Lee7AHv8Cr5JBFohyTtdqxNpAOOnKucLNkkP3YLd0feGNFs=,iv:Abv9UBua6rl+AjrtGEwMEiEaq1r77sZxR8MWd/yqk0M=,tag:DHceBSYOZtfUnzni+bBBsw==,type:str]
+    pgp:
+        - created_at: "2022-02-10T10:55:47Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQGMA80qvHKdsLbXAQv9H3jjgMcoaEpZssNLUg1eNDYKN1aNeetzcI4vGe5U80ke
+            /udgzkK9RGWw92XAa+yKRg5WxbzmoCldzy7L6hAg1xqQSSAoUL3Ity2d67I6n3Lc
+            pxpPTxpeTuXQOgy6cC6lNOwZF6AaYCKrx0Sq7DFuUQqY9Woej4R7hzRh40aPFx5Y
+            cbf7bMNLa+BOGu6OwyTFFUasQ5pqP1l58VBRLYbJLXYqsNcGSRVeeGWVVtpSC3hi
+            Q4IvA6DtSbNsgli42urAlN/ss/JzBqPSCvK7x7vaY8fWGFBTsRXCKJK2tkM+Wqah
+            Q44ohQ6e7U8NfbigGOJh+JoMnXJWabPpfl7s95fdL0+krEwjsdnAxRL8rYquYcGR
+            2EpCEb32gT8R/1uBJyz4BuW6w5B+8EQYBsmE8bQr0bWLKVjpNTEIJ/3//2Eb7cte
+            Pz1dgwMIOK+tzxiUTYyFYFjVtlXJISLJymqjuvhX0MiNgly22mRF53XBsVCgyqVH
+            3nLmuRhj8f5tDNjT/SFw0l4BHS4zWq75666UAb5ZV6fAd+GKiKV5I3gaNxwRYyGu
+            fGEX0qKQc4nCXo9UpJ6KW7gm/o+IYv0Bux+n68P2h5JvEOx6K8RIrZHeg2kfYaEk
+            jH4GLTc+sGZ2K9lZpWSt
+            =vnOJ
+            -----END PGP MESSAGE-----
+          fp: AF73310D7745761A4014FF8F12C8076653BBA9D4
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/clusters/inteli-stage/secrets/t1_t1_account-keys.yaml
+++ b/clusters/inteli-stage/secrets/t1_t1_account-keys.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+    account_seed: ENC[AES256_GCM,data:mC6pcaMjHv86OKU5veC3joznEKCRBo5h12yp8OQTGZmwDNUiysN3hY4arPf7ImnwaXYGY/GsvO3Rbvht2Z8dwfLd1/ev74aSWXnaLd3NEpLbehOEFcmR0zTuWbis9wjlRjyHmsfg8jR+6NVk,iv:P7wPDcnX+qF5yLHChX/Q8EBZKpCFekRAgtV8ZTZq0h0=,tag:Zg8+ZS9XEab+FlQriqAbpA==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: t1-keys
+    namespace: t1
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-02-10T10:55:48Z"
+    mac: ENC[AES256_GCM,data:NhulRVplD1pqP1nROroF56Y/Ic3a7XvWlIe8mZpob0jVKZ6hu8wcJCsZQyL1gdKbfiz6EtWPUJAvAR92B3IdJus5RimFOKbFIknC56q6+KQTR4XalEswPWArBx1CWHW1JUNQj/fuN4BlXyelrllaWE0vyGOo76vTUSHrI+M3ml8=,iv:FUS2WvEzHj0plfxyZJ1h/yT1xNe+DxmIHLLWR3cJ0uI=,tag:fLoD7Zoj/6LkACbWjoQLhg==,type:str]
+    pgp:
+        - created_at: "2022-02-10T10:55:48Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQGMA80qvHKdsLbXAQwAodgsP8dzeGbQtSk7NelE4UjB8maxqtlNlYiVmbCDyxlp
+            tEw+zIrQZt9Jb/wSuGdMQZS+W9TPysgf9ab8QbGzcrMK3TAyOYGwKobD6QiLsaPy
+            7Kdz+vZ+DSJHohO7rBSGbJDCWvx1H34chNtvxkETf7reuA/j0KMqXJDlyU4rmlLv
+            XOvK1y9ph2iXNw7BJgyLiUkbDsBt+Bn9IW0dcnQvS+lqGvynCqMXKEuBILSl/4H7
+            yB/JLxJbBU2MRfgGBYr1+qNfjOKC5QKCTtKp4Le4nVCZoEs2u4Nq6+fT38Y/g6h8
+            J9yanUJmVj2G9Kgyqwfvm73k1GL0HNu4ut9WpRkS2QaCH+puSkaU6nALLhrk+kib
+            Ck9MJoNLpNTcg3tgI98ciQLwgrHLNAPSU364KjPaA5Q0y32NMay1ELzfifbEr6Ef
+            8A7LZjAv49fcDL0/i6OQiu1hEmIhr3c0lFXUeTsrTGNOPfbnT52UvjCwCHIRUJ+1
+            CuawLoIRHT6iZsPVWX020l4BDRm53s1zjKWv7GACvwKA/aNR5bm70fPUyNjD6ZQQ
+            EobzFGBGwXyGlvLaJHg1xrUGU8s8hqy0qIhn1TVsiZS5BoYI7jHdlP0axMJzaLgN
+            Ze/FEXGsl3OS5JoBwshz
+            =HWYQ
+            -----END PGP MESSAGE-----
+          fp: AF73310D7745761A4014FF8F12C8076653BBA9D4
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/clusters/inteli-stage/secrets/t2_t2_account-keys.yaml
+++ b/clusters/inteli-stage/secrets/t2_t2_account-keys.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+data:
+    account_seed: ENC[AES256_GCM,data:KhCt8TugHJ+hZ6RbfYEPPytJj8PqeGYiic9yZ9c3jxcDoPkOEjjHBJiUfWO8by2tSUhOuS0SNh02m+rsDj689ZYekQ6R7f5YatOAdU84XP2E+AXWJvoSMkb4GFrJLUi9W4/Dxy9J5mg=,iv:0m/oIxEAfTKfBsPeFwL7MP0YzeZge9NNsfeYUQ8IgO8=,tag:RL2/3uRW4aqg1AcJWllPKA==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: t2-keys
+    namespace: t2
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-02-10T10:55:48Z"
+    mac: ENC[AES256_GCM,data:tsZMn8pf8soz1SRL1s/iQCwbZHplSQNPViryX0DFy6BkCaeRa6Y4S7RtUHrM7oyMw587gagWqJQXCYw0jUTrqhUjuNNfBT3MGh8oVDEFBPr/kKLepL7vXW5a7GTbf6BHZFhWAZXm5icdPl0VbqFddD6QD3ubWsUZpaMFWBsoadk=,iv:v5i5tn/cU/lf9aYCI3hagQalN6jEDHvcwySMS6QGah4=,tag:k33yR3I4vUdmvFdrEHnY7A==,type:str]
+    pgp:
+        - created_at: "2022-02-10T10:55:48Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQGMA80qvHKdsLbXAQwAn6Uw8sZRWHNTpKdW4fhkz3RsSr8JJLoiL5/TsYYLX30N
+            Pj1nM/4dT46zrNt4f4eGQw3g8ehSlfOOAEzhhkG8C2BYuP+EU2wIv5i59rRGZPlf
+            pz8Cv1EGXBZkTfD7zffYyNZfM8XYieyiVoGlHcV6ciKu3PnDZEH27lSFyEgmFxUz
+            yL0uyBoKiyru/YuMhESQaz6pAYF6dXaSk5aTHCci1YuGDVlVwKiUS0vEHwaMXcHY
+            YJR7nRZoboZTKCseqcFuBaT6V0C6nqw25x344/8IHDLjQggoRBLCfTfcgLre7/Nx
+            GGgFCpi89hOsBgf+ihJaTfLtQhxdbtY2qJJ6Neu0l5M6TOfvUkk5YKpFyNrewHGh
+            C+IelsWDzWdam8kEdpGugQXCjCis4BqusQzSMNeEsl21bApP7fWAWrqnKK28zdEV
+            aSVhA+QYHPcxwipBAM5HdT0dxxdIPXCAHChZb8v/Tepx8m/rk19QtwjiorcSBaRa
+            uqZFMVT0Vly4++EUi/Gn0l4BaD8A+H+BLmWR9RkvHakOZREm9vV0Og9pv6QDRZkQ
+            J12nF04yByway70aYmzS5oADlXI3qNeAFZB0KNKbbYq4/u2QdgPcbjDuU53yr5J4
+            /220ILiHHwpmYGzp9aCX
+            =XyOb
+            -----END PGP MESSAGE-----
+          fp: AF73310D7745761A4014FF8F12C8076653BBA9D4
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/scripts/encrypt-secrets.sh
+++ b/scripts/encrypt-secrets.sh
@@ -64,29 +64,11 @@ assert_command() {
   printf "OK\n"
 }
 
-assert_gpg() {
-  printf "Checking for presense of gpg..."
-  local path_to_executable=$(command -v gpg)
-
-  if [ -z "$path_to_executable" ] ; then
-    echo -e "Cannot find gpg executable. Is it on your \$PATH?"
-    exit 1
-  fi
-
-  if $path_to_executable --version | head -n 1 | grep -E "2.2.27|2.2.19" &> /dev/null ; then
-  printf "OK\n"
-  else
-    echo -e "Incorrect version of gpg detected, make sure you are using 2.2.27 or 2.2.19"
-    $path_to_executable --version |head -n 1
-    exit 1
-  fi
-}
-
 # sanity check
 
 
 assert_cluster $CLUSTER
-assert_gpg
+assert_command gpg
 assert_command sops
 
 # check we can decrypt secrets if we need to

--- a/scripts/make-cluster-account-secret.sh
+++ b/scripts/make-cluster-account-secret.sh
@@ -143,7 +143,7 @@ create_k8s_secret() {
   kubectl create secret generic ${account_name}-keys \
     --type=Opaque \
     --namespace=$namespace \
-    --from-literal=acount_seed="$account_seed" \
+    --from-literal=account_seed="$account_seed" \
     --dry-run=client \
     --output=yaml > ./clusters/${cluster}/secrets/${account_name}_${namespace}_account-keys.unc.yaml
 

--- a/scripts/make-new-cluster-genesis.sh
+++ b/scripts/make-new-cluster-genesis.sh
@@ -293,7 +293,7 @@ generate_node() {
     fi
   done
 
-  printf "Generating keys for $type node $node_name..." >&2
+  printf "Generating keys for $type node $node_name:$namespace..." >&2
   if output=$(./scripts/make-cluster-node-secret.sh -n $namespace -c $container $cluster $node_name 2>/dev/null); then
     printf "OK\n" >&2
     # extract ids
@@ -308,7 +308,7 @@ generate_node() {
     # convert node_id to hex
     node_id=$(docker run --rm -a stdout python:alpine /bin/sh -c "\
       pip install base58 1>/dev/null; \
-      printf \"$node_id\" | base58 -d | xxd -p | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]'")
+      printf \"$node_id\" | base58 -d | xxd -p | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]'" 2>/dev/null)
     node_id=($(echo $node_id | fold -w2))
 
     GENESIS=$(echo $GENESIS | jq --arg owner $node_owner_account '.genesis.runtime.palletNodeAuthorization.nodes += [[[], $owner]]')


### PR DESCRIPTION
secrets created with
```
./scripts/make-new-cluster-genesis.sh \
    -o oem:oem:1152921504606846976 \
    -o t1:t1:1152921504606846976 \
    -o t2:t2:1152921504606846976 \
    -v oem-0:oem:oem \
    -v oem-1:oem:oem \
    -a bn:oem:oem \
    -a ipfs-bn-light:oem:oem \
    -a api-ipfs-light:oem:oem \
    -a id-light:oem:oem \
    -v t1-0:t1:t1 \
    -v t1-1:t1:t1 \
    -a api-ipfs-light:t1:t1 \
    -a id-light:t1:t1 \
    -a api-ipfs-light:t2:t2 \
    -a id-light:t2:t2 \
    inteli-stage > genesis-raw.json
```
This creates accounts for the `oem` `t1` and `t2` personas. 4 validator nodes (shared between `oem` and `t1`) and a bunch of additional nodes.

Also a couple of minor adjustments to scripts